### PR TITLE
Add a return method for Web App

### DIFF
--- a/buckinghampy/buckinghampi.py
+++ b/buckinghampy/buckinghampi.py
@@ -287,9 +287,7 @@ class BuckinghamPi:
             display(Math(latex_str))
             display(Markdown('---'))
 
-    def __tabulate_print(self,latex_string=False):
-        ''' print the dimensionless sets in a tabulated format'''
-
+    def __get_latex_form(self,latex_string=False):
         latex_form = []
         for pi_set in self.__allpiterms:
             latex_set = []
@@ -312,7 +310,11 @@ class BuckinghamPi:
         for num, set in enumerate(latex_form):
             set.insert(0, num + 1)
 
-        print(tabulate(latex_form, headers=headers))
+        return latex_form
+
+    def __tabulate_print(self,latex_string=False):
+        ''' print the dimensionless sets in a tabulated format'''
+        print(tabulate(self.__get_latex_form(latex_string), headers=headers))
 
     def print_all(self, latex_string=False):
         '''
@@ -327,3 +329,7 @@ class BuckinghamPi:
         except:
             ''' print the dimensionless sets in a tabulated format when in terminal session'''
             self.__tabulate_print(latex_string)
+
+    def return_all(self,latex_string=False):
+        ''' return all of the latex output in a dict for easier downstream processing '''
+        return self.__get_latex_form(latex_string) 

--- a/buckinghampy/buckinghampi.py
+++ b/buckinghampy/buckinghampi.py
@@ -244,7 +244,8 @@ class BuckinghamPi:
 
         # remove duplicates from the main dict of all pi terms
         for dup in duplicate:
-            self.__allpiterms.remove(dup)
+            if dup in self.__allpiterms:
+                self.__allpiterms.remove(dup)
         return duplicate
 
     def __populate_prefixed_dimensionless_groups(self):


### PR DESCRIPTION
Adds a `return_all` function that returns the raw data structure without parsing it. It complements the existing `print_all`.

Git rendered the diff in kind of a confusing way, but basically I just pulled the latex logic into its own method (`__get_latex_form`) so that it could be used by both `print_all` and the new function, `return_all`, without repetition.